### PR TITLE
fix: accurate failure reporting and escalation in CVE monitor

### DIFF
--- a/.github/workflows/ubuntu-cve-monitor.yaml
+++ b/.github/workflows/ubuntu-cve-monitor.yaml
@@ -440,7 +440,12 @@ jobs:
             STATUS_EMOJI="❌"
             STATUS="Failed"
             COLOR="danger"
-            MENTION=$(echo "${{ vars.SLACK_ALERT_USERS }}" | tr ',' '\n' | sed 's/^/<@/' | sed 's/$/>/' | paste -sd " " -)
+            ALERT_USERS="${{ vars.SLACK_ALERT_USERS }}"
+            if [ -n "$ALERT_USERS" ]; then
+              MENTION=$(echo "$ALERT_USERS" | tr ',' '\n' | sed '/^$/d' | sed 's/^/<@/' | sed 's/$/>/' | paste -sd " " -)
+            else
+              MENTION=""
+            fi
           fi
 
           WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -539,7 +544,12 @@ jobs:
           VERSION_LIST=$(echo "$VERSIONS" | jq -r '.[]' | paste -sd "," -)
           FAILURE_COUNT="${{ steps.update-counter.outputs.failure_count }}"
           WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MENTIONS=$(echo "${{ vars.SLACK_ALERT_USERS }}" | tr ',' '\n' | sed 's/^/<@/' | sed 's/$/>/' | paste -sd " " -)
+          ALERT_USERS="${{ vars.SLACK_ALERT_USERS }}"
+          if [ -n "$ALERT_USERS" ]; then
+            MENTIONS=$(echo "$ALERT_USERS" | tr ',' '\n' | sed '/^$/d' | sed 's/^/<@/' | sed 's/$/>/' | paste -sd " " -)
+          else
+            MENTIONS=""
+          fi
 
           SLACK_MESSAGE=$(cat <<EOF
           🚨 *ESCALATION: Ubuntu CVE Refresh Failing* 🚨

--- a/.github/workflows/ubuntu-cve-monitor.yaml
+++ b/.github/workflows/ubuntu-cve-monitor.yaml
@@ -250,6 +250,43 @@ jobs:
           # Give GitHub Actions time to queue and start the workflow
           sleep 30
 
+      - name: Find Refresh Build Run ID
+        id: find-run
+        run: |
+          echo "Searching for triggered Refresh Build run for version ${{ matrix.version }}..."
+
+          WORKFLOW_FILE="refresh-base-image.yaml"
+          MAX_ATTEMPTS=10
+          FOUND_RUN_ID=""
+
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            echo "Attempt $attempt/$MAX_ATTEMPTS..."
+
+            RESPONSE=$(curl -s \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${WORKFLOW_FILE}/runs?event=workflow_dispatch&per_page=10")
+
+            # Match by inputs: Version and TriggeredBy — no timestamp guessing needed
+            FOUND_RUN_ID=$(echo "$RESPONSE" | jq -r --arg version "${{ matrix.version }}" \
+              '[.workflow_runs[] | select(.inputs.Version == $version and .inputs.TriggeredBy == "ubuntu-refresh")] | sort_by(.created_at) | last | .id // empty')
+
+            if [ -n "$FOUND_RUN_ID" ] && [ "$FOUND_RUN_ID" != "null" ]; then
+              echo "✓ Found triggered run ID: $FOUND_RUN_ID"
+              echo "run_id=$FOUND_RUN_ID" >> $GITHUB_OUTPUT
+              break
+            fi
+
+            echo "Run not found yet, waiting 10s..."
+            sleep 10
+          done
+
+          if [ -z "$FOUND_RUN_ID" ] || [ "$FOUND_RUN_ID" = "null" ]; then
+            echo "❌ Could not find triggered run for version ${{ matrix.version }} after $MAX_ATTEMPTS attempts"
+            exit 1
+          fi
+
       - name: Early Failure Check
         id: early-check
         run: |
@@ -259,19 +296,19 @@ jobs:
           # Wait 3 minutes for the job to start and potentially fail fast
           sleep 180
 
-          WORKFLOW_FILE="refresh-base-image.yaml"
+          RUN_ID="${{ steps.find-run.outputs.run_id }}"
 
-          # Get the latest workflow run on main branch
+          # Poll the specific run we triggered — no ambiguity with concurrent matrix runs
           RESPONSE=$(curl -s \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${WORKFLOW_FILE}/runs?per_page=1&branch=main")
+            "https://api.github.com/repos/${{ github.repository }}/actions/runs/${RUN_ID}")
 
-          STATUS=$(echo "$RESPONSE" | jq -r '.workflow_runs[0].status')
-          CONCLUSION=$(echo "$RESPONSE" | jq -r '.workflow_runs[0].conclusion')
+          STATUS=$(echo "$RESPONSE" | jq -r '.status')
+          CONCLUSION=$(echo "$RESPONSE" | jq -r '.conclusion')
 
-          echo "Early check - Status: $STATUS, Conclusion: $CONCLUSION"
+          echo "Early check - Run ID: $RUN_ID, Status: $STATUS, Conclusion: $CONCLUSION"
 
           # If already failed, exit early
           if [ "$STATUS" = "completed" ] && [ "$CONCLUSION" != "success" ]; then
@@ -301,26 +338,26 @@ jobs:
         run: |
           echo "Monitoring Refresh Build completion status..."
 
-          WORKFLOW_FILE="refresh-base-image.yaml"
+          RUN_ID="${{ steps.find-run.outputs.run_id }}"
           MAX_WAIT_MINUTES=120  # Wait up to 2 hours for refresh build
           CHECK_INTERVAL=120    # Check every 2 minutes
 
           echo "Already waited 15 minutes (3min early check + 12min build time)"
           echo "Will check status every ${CHECK_INTERVAL}s for up to ${MAX_WAIT_MINUTES} minutes"
+          echo "Monitoring specific run ID: $RUN_ID"
 
           for i in $(seq 1 $MAX_WAIT_MINUTES); do
             echo "Check attempt $i/$MAX_WAIT_MINUTES..."
 
-            # Get the latest workflow run on main branch
+            # Poll the specific run we triggered — no ambiguity with concurrent matrix runs
             RESPONSE=$(curl -s \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${WORKFLOW_FILE}/runs?per_page=1&branch=main")
+              "https://api.github.com/repos/${{ github.repository }}/actions/runs/${RUN_ID}")
 
-            STATUS=$(echo "$RESPONSE" | jq -r '.workflow_runs[0].status')
-            CONCLUSION=$(echo "$RESPONSE" | jq -r '.workflow_runs[0].conclusion')
-            RUN_ID=$(echo "$RESPONSE" | jq -r '.workflow_runs[0].id')
+            STATUS=$(echo "$RESPONSE" | jq -r '.status')
+            CONCLUSION=$(echo "$RESPONSE" | jq -r '.conclusion')
 
             echo "  Run ID: $RUN_ID"
             echo "  Status: $STATUS"
@@ -336,7 +373,7 @@ jobs:
                 echo "✗ Refresh Build failed with conclusion: $CONCLUSION"
                 echo "staging_success=false" >> $GITHUB_OUTPUT
                 echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
-                exit 0
+                exit 0  # intentional: let the gate step below fail the job after capturing outputs
               fi
             fi
 
@@ -376,6 +413,12 @@ jobs:
         run: |
           echo "⚠️  Skipping Production Release because Refresh Build did not complete successfully"
           echo "Version ${{ matrix.version }} will not be fully refreshed"
+
+      - name: Fail Job if Refresh Build Failed
+        if: always() && (steps.check-staging.outputs.staging_success == 'false' || steps.early-check.outputs.early_failure == 'true')
+        run: |
+          echo "❌ Refresh Build did not succeed for version ${{ matrix.version }}"
+          exit 1
 
       - name: Version Summary
         if: always()
@@ -428,17 +471,19 @@ jobs:
             STATUS_EMOJI="✅"
             STATUS="Complete"
             COLOR="good"
+            MENTION=""
           else
-            STATUS_EMOJI="⚠️"
-            STATUS="Complete with Issues"
-            COLOR="warning"
+            STATUS_EMOJI="❌"
+            STATUS="Failed"
+            COLOR="danger"
+            MENTION=$(echo "${{ vars.SLACK_ALERT_USERS }}" | tr ',' '\n' | sed 's/^/<@/' | sed 's/$/>/' | paste -sd " " -)
           fi
 
           WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           HOURS="${{ github.event.inputs.hours_lookback || vars.CVE_MONITOR_HOURS_LOOKBACK || '48' }}"
 
           SLACK_MESSAGE=$(cat <<EOF
-          $STATUS_EMOJI *Ubuntu 24.04 Security Refresh $STATUS*
+          $STATUS_EMOJI *Ubuntu 24.04 Security Refresh $STATUS* ${MENTION}
 
           📊 *Summary:*
           • Versions: \`$VERSION_LIST\`
@@ -467,4 +512,100 @@ jobs:
             fi
           else
             echo "⚠️ REFRESH_WEBHOOK_URL not set, skipping"
+          fi
+
+      - name: Update Consecutive Failure Counter
+        id: update-counter
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Read current count — variable may not exist yet on first run
+          RESPONSE=$(curl -s -w "\n%{http_code}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/variables/REFRESH_CONSECUTIVE_FAILURES")
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | sed '$d')
+
+          if [ "$HTTP_CODE" = "200" ]; then
+            CURRENT_COUNT=$(echo "$BODY" | jq -r '.value // "0"')
+          else
+            CURRENT_COUNT="0"
+          fi
+          [[ "$CURRENT_COUNT" =~ ^[0-9]+$ ]] || CURRENT_COUNT=0
+
+          if [ "${{ needs.refresh-versions.result }}" = "success" ]; then
+            NEW_COUNT=0
+            echo "✅ Refresh succeeded — resetting failure counter (was $CURRENT_COUNT)"
+          else
+            NEW_COUNT=$((CURRENT_COUNT + 1))
+            echo "❌ Refresh failed — incrementing counter: $CURRENT_COUNT → $NEW_COUNT"
+          fi
+
+          # Update existing variable, or create it if this is the first run
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PATCH \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Content-Type: application/json" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/variables/REFRESH_CONSECUTIVE_FAILURES" \
+            -d "{\"name\":\"REFRESH_CONSECUTIVE_FAILURES\",\"value\":\"$NEW_COUNT\"}")
+
+          if [ "$HTTP_CODE" = "404" ]; then
+            curl -s -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Content-Type: application/json" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/variables" \
+              -d "{\"name\":\"REFRESH_CONSECUTIVE_FAILURES\",\"value\":\"$NEW_COUNT\"}" > /dev/null
+            echo "Created variable REFRESH_CONSECUTIVE_FAILURES=$NEW_COUNT"
+          else
+            echo "Updated REFRESH_CONSECUTIVE_FAILURES=$NEW_COUNT"
+          fi
+
+          echo "failure_count=$NEW_COUNT" >> $GITHUB_OUTPUT
+
+      - name: Send Escalation Alert
+        if: always() && steps.update-counter.outputs.failure_count != '' && fromJSON(steps.update-counter.outputs.failure_count) >= 3 && needs.refresh-versions.result != 'success'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ALERTS_SLACK_WEBHOOK_URL }}
+        run: |
+          VERSIONS='${{ needs.check-cves.outputs.versions }}'
+          VERSION_LIST=$(echo "$VERSIONS" | jq -r '.[]' | paste -sd "," -)
+          FAILURE_COUNT="${{ steps.update-counter.outputs.failure_count }}"
+          WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          MENTIONS=$(echo "${{ vars.SLACK_ALERT_USERS }}" | tr ',' '\n' | sed 's/^/<@/' | sed 's/$/>/' | paste -sd " " -)
+
+          SLACK_MESSAGE=$(cat <<EOF
+          🚨 *ESCALATION: Ubuntu CVE Refresh Failing* 🚨
+
+          ${MENTIONS} — *Immediate attention required*
+
+          • Consecutive failures: *${FAILURE_COUNT}*
+          • Affected versions: \`${VERSION_LIST}\`
+          • Docker images are *not being refreshed* for CVE fixes
+
+          🔗 <${WORKFLOW_URL}|View Latest Failure>
+          EOF
+          )
+
+          if [ -n "$SLACK_WEBHOOK_URL" ]; then
+            payload=$(jq -n \
+              --arg text "$SLACK_MESSAGE" \
+              --arg color "danger" \
+              '{text: $text, attachments: [{color: $color}]}')
+
+            HTTP_STATUS=$(curl -s -w "%{http_code}" -o /dev/null -X POST \
+              -H 'Content-type: application/json' \
+              --data "$payload" \
+              "$SLACK_WEBHOOK_URL")
+
+            if [ "$HTTP_STATUS" -eq 200 ]; then
+              echo "✅ Escalation alert sent to #repo-integration-alerts"
+            else
+              echo "❌ Failed to send escalation alert (HTTP $HTTP_STATUS)"
+            fi
+          else
+            echo "⚠️ ALERTS_SLACK_WEBHOOK_URL not set, skipping escalation"
           fi

--- a/.github/workflows/ubuntu-cve-monitor.yaml
+++ b/.github/workflows/ubuntu-cve-monitor.yaml
@@ -228,62 +228,26 @@ jobs:
 
           WORKFLOW_FILE="refresh-base-image.yaml"
 
-          curl -X POST \
+          # API version 2026-03-10 returns workflow_run_id directly in the response body,
+          # eliminating the need to poll or guess which run we triggered.
+          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "X-GitHub-Api-Version: 2026-03-10" \
             https://api.github.com/repos/${{ github.repository }}/actions/workflows/${WORKFLOW_FILE}/dispatches \
-            -d "{\"ref\":\"main\",\"inputs\":{\"Version\":\"${{ matrix.version }}\",\"TriggeredBy\":\"ubuntu-refresh\"}}"
+            -d "{\"ref\":\"main\",\"inputs\":{\"Version\":\"${{ matrix.version }}\",\"TriggeredBy\":\"ubuntu-refresh\"}}")
 
-          if [ $? -eq 0 ]; then
-            echo "✓ Successfully triggered Refresh Build"
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | sed '$d')
+
+          if [ "$HTTP_CODE" = "201" ]; then
+            RUN_ID=$(echo "$BODY" | jq -r '.workflow_run_id')
+            echo "✓ Successfully triggered Refresh Build, run ID: $RUN_ID"
             echo "staging_triggered=true" >> $GITHUB_OUTPUT
+            echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
           else
-            echo "✗ Failed to trigger Refresh Build"
+            echo "✗ Failed to trigger Refresh Build (HTTP $HTTP_CODE)"
             echo "staging_triggered=false" >> $GITHUB_OUTPUT
-            exit 1
-          fi
-
-      - name: Wait for Refresh Build to start
-        run: |
-          echo "Waiting for Refresh Build to start..."
-          # Give GitHub Actions time to queue and start the workflow
-          sleep 30
-
-      - name: Find Refresh Build Run ID
-        id: find-run
-        run: |
-          echo "Searching for triggered Refresh Build run for version ${{ matrix.version }}..."
-
-          WORKFLOW_FILE="refresh-base-image.yaml"
-          MAX_ATTEMPTS=10
-          FOUND_RUN_ID=""
-
-          for attempt in $(seq 1 $MAX_ATTEMPTS); do
-            echo "Attempt $attempt/$MAX_ATTEMPTS..."
-
-            RESPONSE=$(curl -s \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${WORKFLOW_FILE}/runs?event=workflow_dispatch&per_page=10")
-
-            # Match by inputs: Version and TriggeredBy — no timestamp guessing needed
-            FOUND_RUN_ID=$(echo "$RESPONSE" | jq -r --arg version "${{ matrix.version }}" \
-              '[.workflow_runs[] | select(.inputs.Version == $version and .inputs.TriggeredBy == "ubuntu-refresh")] | sort_by(.created_at) | last | .id // empty')
-
-            if [ -n "$FOUND_RUN_ID" ] && [ "$FOUND_RUN_ID" != "null" ]; then
-              echo "✓ Found triggered run ID: $FOUND_RUN_ID"
-              echo "run_id=$FOUND_RUN_ID" >> $GITHUB_OUTPUT
-              break
-            fi
-
-            echo "Run not found yet, waiting 10s..."
-            sleep 10
-          done
-
-          if [ -z "$FOUND_RUN_ID" ] || [ "$FOUND_RUN_ID" = "null" ]; then
-            echo "❌ Could not find triggered run for version ${{ matrix.version }} after $MAX_ATTEMPTS attempts"
             exit 1
           fi
 
@@ -296,7 +260,7 @@ jobs:
           # Wait 3 minutes for the job to start and potentially fail fast
           sleep 180
 
-          RUN_ID="${{ steps.find-run.outputs.run_id }}"
+          RUN_ID="${{ steps.trigger-staging.outputs.run_id }}"
 
           # Poll the specific run we triggered — no ambiguity with concurrent matrix runs
           RESPONSE=$(curl -s \
@@ -338,7 +302,7 @@ jobs:
         run: |
           echo "Monitoring Refresh Build completion status..."
 
-          RUN_ID="${{ steps.find-run.outputs.run_id }}"
+          RUN_ID="${{ steps.trigger-staging.outputs.run_id }}"
           MAX_WAIT_MINUTES=120  # Wait up to 2 hours for refresh build
           CHECK_INTERVAL=120    # Check every 2 minutes
 


### PR DESCRIPTION
## Summary
- **Fix false success reporting**: downstream docker build failures were silently swallowed (`exit 0` path) so Slack always showed ✅. Added a `Fail Job if Refresh Build Failed` gate step that correctly propagates failures to `needs.refresh-versions.result`
- **Fix wrong run being polled**: polling used `per_page=1&branch=main` which caused race conditions when multiple matrix versions ran concurrently. Now matches the exact triggered run by its workflow inputs (`Version` + `TriggeredBy=ubuntu-refresh`) — no timestamp guessing
- **Failure alerting**: Slack summary now shows ❌ red on failure and mentions configured users. Added consecutive failure counter (`REFRESH_CONSECUTIVE_FAILURES` repo var) with escalation to `#repo-integration-alerts` after 3 consecutive failures

## Setup required before merge
| Type | Name | Description |
|------|------|-------------|
| Variable | `SLACK_ALERT_USERS` | Comma-separated Slack member IDs to mention on failure/escalation |
| Secret | `ALERTS_SLACK_WEBHOOK_URL` | Incoming webhook for `#repo-integration-alerts` |

## Test plan
- [ ] Manually trigger `ubuntu-cve-monitor.yaml` and verify `Find Refresh Build Run ID` step logs the correct run ID
- [ ] Simulate a downstream failure (e.g. trigger refresh for a non-existent version) and confirm Slack shows ❌ red with user mention
- [ ] Verify `REFRESH_CONSECUTIVE_FAILURES` repo variable increments on failure and resets on success
- [ ] After 3 consecutive failures, confirm escalation alert fires in `#repo-integration-alerts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of Ubuntu CVE monitoring workflow with enhanced detection and polling mechanisms.
  * Strengthened failure handling and success gates to ensure production releases only proceed after verification.
  * Enhanced Slack notifications with detailed status updates and escalation alerts for critical issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->