### PR TITLE
feat: retry-once-then-alert for CVE monitor refresh builds

### DIFF
--- a/.github/workflows/ubuntu-cve-monitor.yaml
+++ b/.github/workflows/ubuntu-cve-monitor.yaml
@@ -431,7 +431,7 @@ jobs:
                   -H "Accept: application/vnd.github+json" \
                   -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
                   -H "X-GitHub-Api-Version: 2022-11-28" \
-                  "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${WORKFLOW_FILE}/runs?event=workflow_dispatch&per_page=5")
+                  "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${WORKFLOW_FILE}/runs?event=workflow_dispatch&per_page=10")
                 RUN_ID=$(echo "$RUNS" | jq -r \
                   --arg since "$BEFORE_DISPATCH" \
                   '[.workflow_runs[] | select(.created_at >= $since)] | sort_by(.created_at) | last | .id // empty')
@@ -452,6 +452,7 @@ jobs:
             echo "✗ Retry dispatch failed (HTTP $HTTP_CODE)"
             echo "Body: $BODY"
             echo "retry_triggered=false" >> $GITHUB_OUTPUT
+            exit 1
           fi
 
       - name: Retry - Wait for Build

--- a/.github/workflows/ubuntu-cve-monitor.yaml
+++ b/.github/workflows/ubuntu-cve-monitor.yaml
@@ -564,7 +564,7 @@ jobs:
             echo "- **Refresh Build Success (retry):** ${{ steps.check-retry.outputs.retry_success }}" >> $GITHUB_STEP_SUMMARY
           fi
 
-          if [ "${{ steps.check-staging.outputs.staging_success }}" = "true" ]; then
+          if [ "${{ steps.check-staging.outputs.staging_success }}" = "true" ] || [ "${{ steps.check-retry.outputs.retry_success }}" = "true" ]; then
             echo "- **Production Release Triggered:** ${{ steps.trigger-production.outputs.production_triggered }}" >> $GITHUB_STEP_SUMMARY
             if [ "${{ steps.check-staging.outputs.run_id }}" != "" ]; then
               echo "- **Refresh Build Run ID:** ${{ steps.check-staging.outputs.run_id }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ubuntu-cve-monitor.yaml
+++ b/.github/workflows/ubuntu-cve-monitor.yaml
@@ -395,6 +395,126 @@ jobs:
           echo "⚠️  Refresh Build did not complete within ${MAX_WAIT_MINUTES} minutes"
           echo "staging_success=false" >> $GITHUB_OUTPUT
 
+      - name: Retry - Trigger Refresh Build for version ${{ matrix.version }}
+        id: trigger-retry
+        if: always() && steps.trigger-staging.outputs.staging_triggered == 'true' && (steps.early-check.outputs.early_failure == 'true' || steps.check-staging.outputs.staging_success == 'false' || steps.check-staging.outputs.staging_success == 'unknown')
+        run: |
+          echo "⚠️ First attempt failed — retrying Refresh Build for version ${{ matrix.version }}..."
+
+          WORKFLOW_FILE="refresh-base-image.yaml"
+          BEFORE_DISPATCH=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/actions/workflows/${WORKFLOW_FILE}/dispatches \
+            -d "{\"ref\":\"main\",\"inputs\":{\"Version\":\"${{ matrix.version }}\",\"TriggeredBy\":\"ubuntu-refresh\"}}")
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | sed '$d')
+
+          if echo "$HTTP_CODE" | grep -qE '^2[0-9]{2}$'; then
+            echo "✓ Retry dispatch accepted (HTTP $HTTP_CODE)"
+            echo "retry_triggered=true" >> $GITHUB_OUTPUT
+
+            RUN_ID=$(echo "$BODY" | jq -r '.workflow_run_id // empty' 2>/dev/null || true)
+
+            if [ -n "$RUN_ID" ] && [ "$RUN_ID" != "null" ]; then
+              echo "✓ Retry run ID from response: $RUN_ID"
+              echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
+            else
+              echo "Response did not include run_id — locating retry run by creation time..."
+              sleep 10
+              for attempt in 1 2 3 4 5; do
+                RUNS=$(curl -s \
+                  -H "Accept: application/vnd.github+json" \
+                  -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                  -H "X-GitHub-Api-Version: 2022-11-28" \
+                  "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${WORKFLOW_FILE}/runs?event=workflow_dispatch&per_page=5")
+                RUN_ID=$(echo "$RUNS" | jq -r \
+                  --arg since "$BEFORE_DISPATCH" \
+                  '[.workflow_runs[] | select(.created_at >= $since)] | sort_by(.created_at) | last | .id // empty')
+                if [ -n "$RUN_ID" ] && [ "$RUN_ID" != "null" ]; then
+                  echo "✓ Located retry run ID: $RUN_ID (attempt $attempt)"
+                  echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
+                  break
+                fi
+                echo "Retry run not yet visible (attempt $attempt/5), retrying in 10s..."
+                sleep 10
+              done
+              if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+                echo "⚠️ Could not locate retry run ID — polling will be skipped"
+                echo "run_id=" >> $GITHUB_OUTPUT
+              fi
+            fi
+          else
+            echo "✗ Retry dispatch failed (HTTP $HTTP_CODE)"
+            echo "Body: $BODY"
+            echo "retry_triggered=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Retry - Wait for Build
+        if: always() && steps.trigger-retry.outputs.retry_triggered == 'true'
+        run: |
+          echo "Retry triggered — waiting 15 minutes for build to run..."
+          sleep 900
+          echo "✓ Wait complete, starting retry status checks"
+
+      - name: Retry - Check Refresh Build status
+        id: check-retry
+        if: always() && steps.trigger-retry.outputs.retry_triggered == 'true'
+        run: |
+          echo "Monitoring retry Refresh Build status..."
+
+          RUN_ID="${{ steps.trigger-retry.outputs.run_id }}"
+          if [ -z "$RUN_ID" ]; then
+            echo "⚠️ No retry run ID available — cannot poll"
+            echo "retry_success=unknown" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          MAX_WAIT_MINUTES=120
+          CHECK_INTERVAL=120
+
+          echo "Will check every ${CHECK_INTERVAL}s for up to ${MAX_WAIT_MINUTES} minutes"
+          echo "Monitoring retry run ID: $RUN_ID"
+
+          for i in $(seq 1 $MAX_WAIT_MINUTES); do
+            echo "Check attempt $i/$MAX_WAIT_MINUTES..."
+
+            RESPONSE=$(curl -s \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/runs/${RUN_ID}")
+
+            STATUS=$(echo "$RESPONSE" | jq -r '.status')
+            CONCLUSION=$(echo "$RESPONSE" | jq -r '.conclusion')
+
+            echo "  Run ID: $RUN_ID | Status: $STATUS | Conclusion: $CONCLUSION"
+
+            if [ "$STATUS" = "completed" ]; then
+              if [ "$CONCLUSION" = "success" ]; then
+                echo "✓ Retry Refresh Build completed successfully"
+                echo "retry_success=true" >> $GITHUB_OUTPUT
+                echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
+                exit 0
+              else
+                echo "✗ Retry Refresh Build also failed: $CONCLUSION"
+                echo "retry_success=false" >> $GITHUB_OUTPUT
+                echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
+                exit 0
+              fi
+            fi
+
+            echo "  Still running, waiting ${CHECK_INTERVAL}s..."
+            sleep $CHECK_INTERVAL
+          done
+
+          echo "⚠️ Retry build did not complete within ${MAX_WAIT_MINUTES} minutes"
+          echo "retry_success=false" >> $GITHUB_OUTPUT
+
       - name: Trigger Production Release for version ${{ matrix.version }}
         if: steps.check-staging.outputs.staging_success == 'true' && steps.early-check.outputs.early_failure != 'true'
         id: trigger-production

--- a/.github/workflows/ubuntu-cve-monitor.yaml
+++ b/.github/workflows/ubuntu-cve-monitor.yaml
@@ -21,6 +21,11 @@ name: Ubuntu 24.04 Base Image OS Refresh (CVE Monitor)
 # Repository Variables (optional, set in Settings > Secrets and variables > Actions > Variables):
 # - CVE_MONITOR_HOURS_LOOKBACK: Override the default lookback period (e.g., '48', '72', '24')
 # - CVE_MONITOR_VERSIONS_COUNT: Override the default number of recent versions to refresh (e.g., '2', '3', '1')
+# - SLACK_ALERT_USERS: Comma-separated Slack member IDs to tag on failure (e.g., 'U012AB3CD,U456EF7GH')
+#
+# Secrets required:
+# - REFRESH_WEBHOOK_URL: Slack webhook for regular build start/complete notifications
+# - ALERTS_SLACK_WEBHOOK_URL: Slack webhook for failure alerts (fires on every retry failure)
 
 on:
   schedule:
@@ -655,66 +660,13 @@ jobs:
             echo "⚠️ REFRESH_WEBHOOK_URL not set, skipping"
           fi
 
-      - name: Update Consecutive Failure Counter
-        id: update-counter
-        if: always()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Read current count — variable may not exist yet on first run
-          RESPONSE=$(curl -s -w "\n%{http_code}" \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            "https://api.github.com/repos/${{ github.repository }}/actions/variables/REFRESH_CONSECUTIVE_FAILURES")
-
-          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
-          BODY=$(echo "$RESPONSE" | sed '$d')
-
-          if [ "$HTTP_CODE" = "200" ]; then
-            CURRENT_COUNT=$(echo "$BODY" | jq -r '.value // "0"')
-          else
-            CURRENT_COUNT="0"
-          fi
-          [[ "$CURRENT_COUNT" =~ ^[0-9]+$ ]] || CURRENT_COUNT=0
-
-          if [ "${{ needs.refresh-versions.result }}" = "success" ]; then
-            NEW_COUNT=0
-            echo "✅ Refresh succeeded — resetting failure counter (was $CURRENT_COUNT)"
-          else
-            NEW_COUNT=$((CURRENT_COUNT + 1))
-            echo "❌ Refresh failed — incrementing counter: $CURRENT_COUNT → $NEW_COUNT"
-          fi
-
-          # Update existing variable, or create it if this is the first run
-          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PATCH \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Content-Type: application/json" \
-            "https://api.github.com/repos/${{ github.repository }}/actions/variables/REFRESH_CONSECUTIVE_FAILURES" \
-            -d "{\"name\":\"REFRESH_CONSECUTIVE_FAILURES\",\"value\":\"$NEW_COUNT\"}")
-
-          if [ "$HTTP_CODE" = "404" ]; then
-            curl -s -X POST \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer $GH_TOKEN" \
-              -H "Content-Type: application/json" \
-              "https://api.github.com/repos/${{ github.repository }}/actions/variables" \
-              -d "{\"name\":\"REFRESH_CONSECUTIVE_FAILURES\",\"value\":\"$NEW_COUNT\"}" > /dev/null
-            echo "Created variable REFRESH_CONSECUTIVE_FAILURES=$NEW_COUNT"
-          else
-            echo "Updated REFRESH_CONSECUTIVE_FAILURES=$NEW_COUNT"
-          fi
-
-          echo "failure_count=$NEW_COUNT" >> $GITHUB_OUTPUT
-
       - name: Send Escalation Alert
-        if: always() && steps.update-counter.outputs.failure_count != '' && fromJSON(steps.update-counter.outputs.failure_count) >= 3 && needs.refresh-versions.result != 'success'
+        if: always() && needs.refresh-versions.result != 'success'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ALERTS_SLACK_WEBHOOK_URL }}
         run: |
           VERSIONS='${{ needs.check-cves.outputs.versions }}'
           VERSION_LIST=$(echo "$VERSIONS" | jq -r '.[]' | paste -sd "," -)
-          FAILURE_COUNT="${{ steps.update-counter.outputs.failure_count }}"
           WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           ALERT_USERS="${{ vars.SLACK_ALERT_USERS }}"
           if [ -n "$ALERT_USERS" ]; then
@@ -728,7 +680,6 @@ jobs:
 
           ${MENTIONS} — *Immediate attention required*
 
-          • Consecutive failures: *${FAILURE_COUNT}*
           • Affected versions: \`${VERSION_LIST}\`
           • Docker images are *not being refreshed* for CVE fixes
 

--- a/.github/workflows/ubuntu-cve-monitor.yaml
+++ b/.github/workflows/ubuntu-cve-monitor.yaml
@@ -517,7 +517,7 @@ jobs:
           echo "retry_success=false" >> $GITHUB_OUTPUT
 
       - name: Trigger Production Release for version ${{ matrix.version }}
-        if: steps.check-staging.outputs.staging_success == 'true' && steps.early-check.outputs.early_failure != 'true'
+        if: always() && (steps.check-staging.outputs.staging_success == 'true' || steps.check-retry.outputs.retry_success == 'true')
         id: trigger-production
         run: |
           echo "Refresh Build succeeded. Triggering Production Release for version ${{ matrix.version }}..."
@@ -541,13 +541,13 @@ jobs:
           fi
 
       - name: Skip Production Release (Refresh Build failed)
-        if: steps.check-staging.outputs.staging_success != 'true'
+        if: always() && steps.check-staging.outputs.staging_success != 'true' && steps.check-retry.outputs.retry_success != 'true' && steps.trigger-retry.outputs.retry_triggered == 'true'
         run: |
           echo "⚠️  Skipping Production Release because Refresh Build did not complete successfully"
           echo "Version ${{ matrix.version }} will not be fully refreshed"
 
       - name: Fail Job if Refresh Build Failed
-        if: always() && (steps.check-staging.outputs.staging_success == 'false' || steps.check-staging.outputs.staging_success == 'unknown' || steps.early-check.outputs.early_failure == 'true')
+        if: always() && steps.check-retry.outputs.retry_success != 'true' && steps.check-staging.outputs.staging_success != 'true' && steps.trigger-staging.outputs.staging_triggered == 'true'
         run: |
           echo "❌ Refresh Build did not succeed for version ${{ matrix.version }}"
           exit 1
@@ -558,7 +558,11 @@ jobs:
           echo "### Version ${{ matrix.version }} Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- **Refresh Build Triggered:** ${{ steps.trigger-staging.outputs.staging_triggered }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Refresh Build Success:** ${{ steps.check-staging.outputs.staging_success }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Refresh Build Success (attempt 1):** ${{ steps.check-staging.outputs.staging_success }}" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.trigger-retry.outputs.retry_triggered }}" = "true" ]; then
+            echo "- **Retry Triggered:** true" >> $GITHUB_STEP_SUMMARY
+            echo "- **Refresh Build Success (retry):** ${{ steps.check-retry.outputs.retry_success }}" >> $GITHUB_STEP_SUMMARY
+          fi
 
           if [ "${{ steps.check-staging.outputs.staging_success }}" = "true" ]; then
             echo "- **Production Release Triggered:** ${{ steps.trigger-production.outputs.production_triggered }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ubuntu-cve-monitor.yaml
+++ b/.github/workflows/ubuntu-cve-monitor.yaml
@@ -315,11 +315,11 @@ jobs:
 
           echo "Early check - Run ID: $RUN_ID, Status: $STATUS, Conclusion: $CONCLUSION"
 
-          # If already failed, exit early
+          # If already failed, record it — gate step will fail the job
           if [ "$STATUS" = "completed" ] && [ "$CONCLUSION" != "success" ]; then
             echo "❌ Refresh Build failed early (within 3 minutes)"
             echo "early_failure=true" >> $GITHUB_OUTPUT
-            exit 1
+            exit 0
           fi
 
           echo "✓ No early failure detected, proceeding to normal monitoring"


### PR DESCRIPTION
## Summary

Replaces the consecutive-failure-counter escalation model with a simpler **retry-once-then-alert** approach.

**Flow:**
```
trigger refresh build
  → if failed: retry once
      → if succeeded: trigger production ✅
      → if failed: job fails, alert fires to both Slack channels ❌
  → if succeeded: trigger production ✅
```

## Changes

- **Early-check step**: no longer exits 1 on fast failure — gate step owns that, allowing retry steps to run
- **Retry block (3 new steps)**: trigger → wait 15m → poll up to 2h — fires only when first attempt fails
- **Gate + production trigger**: wired to retry result — a successful retry triggers production and passes the job
- **Removed**: `Update Consecutive Failure Counter` step and all `REFRESH_CONSECUTIVE_FAILURES` variable logic
- **Escalation**: fires immediately on any persistent failure (both attempts failed), no 3-day wait

## Required setup

| Type | Name | Value |
|------|------|-------|
| Variable | `SLACK_ALERT_USERS` | Comma-separated Slack member IDs, e.g. `U012AB3CD,U456EF7GH` |
| Secret | `ALERTS_SLACK_WEBHOOK_URL` | Incoming webhook URL for `#repo-integration-alerts` |

If `REFRESH_CONSECUTIVE_FAILURES` exists as a repo variable (created by a previous run), it can be deleted from Settings → Secrets and variables → Actions → Variables.

## Test plan

- [ ] Success path: verify job passes, production triggered, no escalation
- [ ] First attempt fails, retry succeeds: verify job passes, production triggered, no escalation
- [ ] Both attempts fail: verify ❌ in refresh channel + escalation in `#repo-integration-alerts` with user mentions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Slack-based notification and escalation alerts for image refresh failures
  * Introduced multi-phase retry workflow for Ubuntu CVE image refresh operations
  * Enhanced status reporting with retry outcomes and explicit escalation indicators

* **Bug Fixes**
  * Improved early-failure handling to enable retry and escalation logic
  * Expanded production release logic with retry success path and failure termination

<!-- end of auto-generated comment: release notes by coderabbit.ai -->