### PR TITLE
WSD-0000 | Comment out checkov config setup block in scanner

### DIFF
--- a/config/scanner-modifications.txt
+++ b/config/scanner-modifications.txt
@@ -32,6 +32,9 @@ COMMENT:install-tool composer
 COMMENT:CHECKOV_VERSION
 COMMENT:install-tool checkov
 
+# Comment out checkov config setup block (irrelevant since checkov itself is commented out)
+COMMENT_BLOCK:/etc/checkov
+
 # Comment out php installation
 COMMENT:PHP_VERSION
 COMMENT:install-tool php


### PR DESCRIPTION
## Jira

N/A

## Summary

- Added `COMMENT_BLOCK:/etc/checkov` to `config/scanner-modifications.txt`
- The upcoming scanner Dockerfile version will include a new RUN block that creates `/etc/checkov/config.yaml` to prevent config injection
- Since checkov itself is already commented out (`CHECKOV_VERSION`, `install-tool checkov`), the config setup block is irrelevant and should be commented out as well

## Test plan

- [ ] Verify `./bin/validate-modifications.sh` passes after the new Dockerfile version is integrated
- [ ] Confirm the new `RUN mkdir -p /etc/checkov` block is commented in both `Dockerfile` and `Dockerfile.full`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated scanner configuration rules to refine how security scanning tools are deployed and configured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mend/docker-base-images/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->