### PR TITLE
WSD-0000 | Fix REPLACE action to preserve comment state and pin golang 1.26.4

### DIFF
--- a/bin/modify-dockerfile.sh
+++ b/bin/modify-dockerfile.sh
@@ -176,8 +176,9 @@ ${replacement}" "$temp_file"
 ${replacement}" "$temp_file"
                 ;;
             "REPLACE")
-                # Replace entire line matching pattern
-                sed -i.bak "s/.*${pattern}.*/${replacement}/" "$temp_file"
+                # Substring replacement — only the matched text is swapped, everything else
+                # on the line (including any leading '#') is preserved unchanged.
+                sed -i.bak "s/${pattern}/${replacement}/" "$temp_file"
                 ;;
             *)
                 echo "  Warning: Unknown action '$action', skipping"

--- a/config/scanner-modifications.txt
+++ b/config/scanner-modifications.txt
@@ -64,3 +64,8 @@ COMMENT_PAIR:ARG GRADLE_VERSION=6\.9\.4:install-tool gradle
 # Comment out .NET 3.1.426 and 5.0.408 only (ARG + adjacent RUN pairs — other dotnet versions unaffected)
 COMMENT_PAIR:ARG DOTNET_VERSION=3\.1\.426:install-tool dotnet
 COMMENT_PAIR:ARG DOTNET_VERSION=5\.0\.408:install-tool dotnet
+
+# Pin golang to 1.26.4 (overrides upstream's 1.26.2 on regeneration)
+# Works for both Dockerfile (commented) and Dockerfile.full (active) — comment state is preserved.
+# If upstream moves off 1.26.2 this will no-op and validation will flag it, prompting a revisit.
+REPLACE:GOLANG_VERSION=1\.26\.2:GOLANG_VERSION=1.26.4


### PR DESCRIPTION
## Summary

- Fixed `REPLACE` action in `modify-dockerfile.sh` to perform substring replacement instead of full-line replacement — comment state (`#`) on matched lines is now preserved unchanged
- Added golang version pin (`1.26.2` → `1.26.4`) to `scanner-modifications.txt` using the corrected `REPLACE` action; works correctly for both `Dockerfile` (commented) and `Dockerfile.full` (active) with a single rule

## Test plan

- [ ] Run `./bin/modify-dockerfile.sh repo-integrations/scanner/Dockerfile config/scanner-modifications.txt` and verify `#ARG GOLANG_VERSION` stays commented at 1.26.4
- [ ] Run `./bin/modify-dockerfile.sh repo-integrations/scanner/Dockerfile.full config/scanner-modifications.txt` and verify `ARG GOLANG_VERSION` stays active at 1.26.4
- [ ] Run `./bin/validate-modifications.sh` and verify all checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved string replacement in build scripts to preserve surrounding content.

* **Chores**
  * Updated Go dependency to a newer patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->