### PR TITLE
WSD-0000 | Fix CVE monitor regex to support any version suffix format

### DIFF
--- a/.github/workflows/ubuntu-cve-monitor.yaml
+++ b/.github/workflows/ubuntu-cve-monitor.yaml
@@ -75,7 +75,7 @@ jobs:
           #           Version format:
           #             - Regular: prod-x.x.x (e.g., prod-25.12.1)
           #             - Hotfix: prod-x.x.x.x (e.g., prod-25.12.1.1)
-          #             - Suffix variant: prod-x.x.x-c1 (e.g., prod-25.12.1-c1)
+          #             - Suffix variant: prod-x.x.x-<suffix> (e.g., prod-25.12.1-c1, prod-25.12.1-c1.1, prod-25.12.1-c1-123)
           #
           #           Tags are created by the prod workflow after a successful Mend Hub publish.
           #
@@ -106,7 +106,7 @@ jobs:
           echo ""
 
           # Get all prod-released tags (including suffix variants), strip the prefix
-          ALL_TAGS=$(git tag | grep -E '^prod-[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?(-[a-zA-Z0-9]+)?$' | sed 's/^prod-//' | sort -V)
+          ALL_TAGS=$(git tag | grep -E '^prod-[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?(-[^ ]+)?$' | sed 's/^prod-//' | sort -V)
 
           if [ -z "$ALL_TAGS" ]; then
             echo "⚠️  No prod-released version tags found in repository"
@@ -121,7 +121,7 @@ jobs:
           # Strip suffix from all tags to derive base versions for major.minor grouping.
           # This ensures suffix-only prod releases (e.g. 26.3.1-c1 with no 26.3.1 base tag)
           # are still represented in the group selection.
-          LATEST_BASE_PER_MINOR=$(echo "$ALL_TAGS" | sed 's/-[a-zA-Z0-9]*$//' | sort -uV | awk -F. '{
+          LATEST_BASE_PER_MINOR=$(echo "$ALL_TAGS" | sed 's/-.*$//' | sort -uV | awk -F. '{
             key = $1 "." $2
             if (key in versions) {
               if ($0 > versions[key]) {
@@ -152,7 +152,7 @@ jobs:
           ALL_VERSIONS_TO_REFRESH=""
           while IFS= read -r BASE; do
             [ -z "$BASE" ] && continue
-            VARIANTS=$(echo "$ALL_TAGS" | grep -E "^${BASE}(-[a-zA-Z0-9]+)?$")
+            VARIANTS=$(echo "$ALL_TAGS" | grep -E "^${BASE}(-[^ ]+)?$")
             ALL_VERSIONS_TO_REFRESH="${ALL_VERSIONS_TO_REFRESH}"$'\n'"$VARIANTS"
           done <<< "$SELECTED_BASES"
           ALL_VERSIONS_TO_REFRESH=$(echo "$ALL_VERSIONS_TO_REFRESH" | grep -v '^$' | sort -u)


### PR DESCRIPTION
## Jira

https://mend-io.atlassian.net/browse/WSD-0000

## Summary

- Version suffixes containing dots or hyphens (e.g., `c1.1`, `c1-123`, `c1.1.1`) were silently dropped by three regex patterns in the CVE monitor workflow that only allowed `[a-zA-Z0-9]` in the suffix portion
- This caused versions like `26.5.1.4-c1.1` to be invisible to the OS refresh pipeline — never extracted from tags, never grouped correctly, never expanded as variants
- The version was published initially but never refreshed in subsequent CVE cycles, becoming progressively stale

**Fixes applied (all in `ubuntu-cve-monitor.yaml`):**

| Line | Pattern | Before | After |
|------|---------|--------|-------|
| 109 | Tag extraction | `(-[a-zA-Z0-9]+)?` | `(-[^ ]+)?` |
| 124 | Suffix stripping | `sed 's/-[a-zA-Z0-9]*$//'` | `sed 's/-.*$//'` |
| 155 | Variant expansion | `(-[a-zA-Z0-9]+)?` | `(-[^ ]+)?` |

## Test plan

- [ ] Verify existing prod tags are still matched (e.g., `prod-26.5.1.4`, `prod-26.5.1.4-c1`)
- [ ] Verify dotted suffixes are now matched (e.g., `prod-26.5.1.4-c1.1`)
- [ ] Run CVE monitor manually with `versions_to_refresh=1` and confirm `c1.1` variant appears in the version list
- [ ] After merge, manually trigger refresh for `26.5.1.4-c1.1` to bring it up to date

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Ubuntu CVE monitor's version tag detection to recognize a wider variety of production tag formats, improving detection accuracy for security vulnerability monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->